### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These are polyglot implementations of the [July 2013 Coder Night problem](https://gist.github.com/ambethia/5960316). A "rosetta stone" of sorts, nearly identical implementations in each target language.
 
-I try to be as idiomatic in each language as possible while staying true to the implementation (to help in making side-by-side comparisions). I'm far from an expert in a lot of these languages, so any feedback on specific techniques is appreciated.
+I try to be as idiomatic in each language as possible while staying true to the implementation (to help in making side-by-side comparisons). I'm far from an expert in a lot of these languages, so any feedback on specific techniques is appreciated.
 
 * ruby √
 * haxe √


### PR DESCRIPTION
@ambethia, I've corrected a typographical error in the documentation of the [LCD](https://github.com/ambethia/LCD) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
